### PR TITLE
Fixed link to #Hello-World Tutorial in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -90,7 +90,7 @@ $app->get(
             <h1>Welcome to Slim!</h1>
             <p>
                 Congratulations! Your Slim application is running. If this is
-                your first time using Slim, start with this <a href="http://docs.slimframework.com/#Hello-World" target="_blank">"Hello World" Tutorial</a>.
+                your first time using Slim, start with this <a href="http://docs.slimframework.com/start/get-started/#hello-world" target="_blank">"Hello World" Tutorial</a>.
             </p>
             <section>
                 <h2>Get Started</h2>


### PR DESCRIPTION
http://docs.slimframework.com/#Hello-World is not deadlink, but 
http://docs.slimframework.com/start/get-started/#hello-world is better.

And though [Lumen happened](http://lumen.laravel.com/), it's not the question of the Slim's future - 
for the sake of the users & companies)
